### PR TITLE
feat: 프로필 사진 등록 및 변경, 프로필 조회, 닉네임 변경

### DIFF
--- a/diary/src/main/java/Toy_Project/diary/Controller/AuthController.java
+++ b/diary/src/main/java/Toy_Project/diary/Controller/AuthController.java
@@ -5,6 +5,7 @@ import Toy_Project.diary.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -33,6 +34,27 @@ public class AuthController {
     @DeleteMapping("/delete")
     public ResponseDto<?> deleteUser(@AuthenticationPrincipal String userEmail) {
         ResponseDto<?> result = authService.deleteUser(userEmail);
+        return result;
+    }
+
+    // 프로필 사진 등록 및 수정
+    @PostMapping("/setPhoto")
+    public ResponseDto<?> setProfilePhoto(@RequestBody MultipartFile file, @AuthenticationPrincipal String userEmail) {
+        ResponseDto<?> result = authService.setProfilePhoto(file, userEmail);
+        return result;
+    }
+
+    // 닉네임 등록 및 수정
+    @PostMapping("/setNickname")
+    public ResponseDto<?> setNickName(@RequestBody String nickname, @AuthenticationPrincipal String userEmail) {
+        ResponseDto<?> result = authService.setNickname(nickname, userEmail);
+        return result;
+    }
+
+    // 프로필 보기
+    @GetMapping("/viewProfile")
+    public ResponseDto<ProfileResponseDto> getProfilePhoto(@AuthenticationPrincipal String userEmail) {
+        ResponseDto<ProfileResponseDto> result = authService.getProfilePhoto(userEmail);
         return result;
     }
 

--- a/diary/src/main/java/Toy_Project/diary/Entity/User.java
+++ b/diary/src/main/java/Toy_Project/diary/Entity/User.java
@@ -48,6 +48,12 @@ public class User {
     @NotNull
     private boolean agreement;
 
+    private String filename;
+
+    private String filepath;
+
+
+
     // 기본적인 getter와 setter 모음
     public String getEmail() {
         return email;

--- a/diary/src/main/java/Toy_Project/diary/dto/ProfileResponseDto.java
+++ b/diary/src/main/java/Toy_Project/diary/dto/ProfileResponseDto.java
@@ -1,0 +1,18 @@
+package Toy_Project.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileResponseDto {
+
+    // 프로필 사진
+    private String userNickname;  // 원본 파일 이름
+    private String resourceUrl;  // URL 문자열로 파일 경로를 저장
+
+}

--- a/diary/src/main/java/Toy_Project/diary/service/AuthService.java
+++ b/diary/src/main/java/Toy_Project/diary/service/AuthService.java
@@ -6,9 +6,21 @@ import Toy_Project.diary.Repository.UserRepository;
 import Toy_Project.diary.dto.*;
 import Toy_Project.diary.security.TokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @Service
 public class AuthService {
@@ -100,6 +112,138 @@ public class AuthService {
         return ResponseDto.setSuccess("Successfully deleted user", userEmail);
 
     }
+
+    // 프로필 사진 설정
+    public ResponseDto<?> setProfilePhoto(MultipartFile file, String userEmail) {
+
+        User user = userRepository.findByEmail(userEmail);
+
+        try {
+            if (user == null) {
+                return ResponseDto.setFailed("user not existed");
+            }
+        } catch (Exception error) {
+            return ResponseDto.setFailed("Data Base Error");
+        }
+
+        String originalFilename = file.getOriginalFilename();
+
+        // 확장자 검사
+        if (originalFilename != null && !originalFilename.isEmpty()) {
+            String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+
+            if (!(extension.equals("png") || extension.equals("jpg") || extension.equals("jpeg"))) {
+                return ResponseDto.setFailed("Invalid file type. Only PNG, JPG and JPEG files are allowed.");
+            }
+
+        } else {
+            return ResponseDto.setFailed("Invalid file name.");
+        }
+
+        // 파일 사이즈 검사(1MB)
+        long fileSizeInBytes = file.getSize();
+        long fileSizeInKB = fileSizeInBytes / 1024;
+        long fileSizeInMB = fileSizeInKB / 1024;
+
+        if(fileSizeInMB > 1){
+            return ResponseDto.setFailed("File size should be less than or equal to 1 MB.");
+        }
+
+        Path projectPath = Paths.get(System.getProperty("user.dir"), "diary", "src", "main", "resources", "static", "files");
+        UUID uuid = UUID.randomUUID();
+        String fileName = uuid + "_" + originalFilename;
+        File saveFile = new File(projectPath.toString(), fileName);
+
+        File directory = new File(projectPath.toString());
+        if (!directory.exists()) {
+            directory.mkdirs(); // 디렉토리가 존재하지 않으면 생성
+        }
+
+        // 이전 프로필 사진 파일 삭제
+        if (user.getFilename() != null) {
+            String oldFileName = user.getFilename();
+            File oldFile = new File(projectPath.toString(), oldFileName);
+            if (oldFile.exists()) {
+                oldFile.delete(); // 이전 파일 삭제
+            }
+        }
+
+        try {
+            // userRepository에 profile photo 변경 사항 update
+            user.setFilename(fileName);
+            user.setFilepath("/files/" + fileName);
+            userRepository.save(user);
+        } catch (Exception error) {
+            return ResponseDto.setFailed("Data Base Error");
+        }
+
+        try {
+            // static/files에 user profile 사진 저장
+            file.transferTo(saveFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseDto.setFailed("파일 저장 중 오류 발생");
+        }
+
+        return ResponseDto.setSuccess("Profile Photo saved successfully", null);
+    }
+
+    // 닉네임 등록 및 수정
+    public ResponseDto<?> setNickname(String nickname, String userEmail) {
+
+        User user = userRepository.findByEmail(userEmail);
+
+        try {
+            if (user == null) {
+                return ResponseDto.setFailed("user not existed");
+            }
+        } catch (Exception error) {
+            return ResponseDto.setFailed("Data Base Error");
+        }
+
+        try {
+            // userRepository에 닉네임 변경 사항 update
+            user.setNickname(nickname);
+            userRepository.save(user);
+        } catch (Exception error) {
+            return ResponseDto.setFailed("Data Base Error");
+        }
+
+        return ResponseDto.setSuccess("Nickname saved successfully", nickname);
+    }
+
+    // 프로필 조회
+    public ResponseDto<ProfileResponseDto> getProfilePhoto(String userEmail) {
+        User user = userRepository.findByEmail(userEmail);
+
+        try {
+            if (user == null) {
+                return ResponseDto.setFailed("User not existed");
+            }
+        } catch (Exception error) {
+            return ResponseDto.setFailed("Database Error");
+        }
+
+        String filename = user.getFilename();
+        Path file = Paths.get(System.getProperty("user.dir"), "diary", "src", "main", "resources", "static", "files", filename);
+        Resource resource = null;
+
+        try {
+            resource = new UrlResource(file.toUri());
+            if (resource.exists() && resource.isReadable()) {
+                // ProfileResponseDto 생성 및 필요한 정보 설정
+                ProfileResponseDto profileResponseDto = new ProfileResponseDto(user.getNickname(), resource.getURL().toString());
+
+                // 성공 응답 반환
+                return ResponseDto.setSuccess("Profile Photo retrieved successfully", profileResponseDto);
+            } else {
+                return ResponseDto.setFailed("Resource not found or not readable");
+            }
+        } catch (IOException e) {
+            return ResponseDto.setFailed("Bad Request Error");
+        }
+    }
+
 
     public ResponseDto<?> emailCheck(ExistsCheckDto dto) {
         String checkEmail = dto.getCheck();


### PR DESCRIPTION
1. 프로필 사진 등록 및 변경: authService.setProfilePhoto
<로직>
- 유저 정보 없으면 에러 반환
- 입력 파일에 대한 확장자 검사: png, jpg, jpeg 파일이 아닐 경우 에러 반환
- 용량 검사: 1MB 이상 파일이 등록될 시 에러 반환
- 이전 프로필 삭제: 이전에 등록된 사진이 있을 경우 삭제해서 저장용량 절약
- user entity에 사진 파일 이름 및 경로 저장 (사진 이름은 UUID로 unique 하게 처리)
- file.transferTo(saveFile); 로 사진 저장 후 실패 시 에러 로그 반환

2. 닉네임 등록 및 변경: authService.setNickname
- user entity에서 닉네임 정보 조회 후 새로 변경 및 set

3. 프로필 조회: authService.getProfilePhoto
- 경로로 파일 조회
- 파일 있을 경우 파일과 닉네임 반환
- 파일이 조회되지 않을 경우 닉네임만 반환, 파일 경로는 null
- 그 외의 에러는 실패 처리